### PR TITLE
Parse debugger statements

### DIFF
--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -152,6 +152,7 @@ class parser {
         this->parse_and_visit_if(v);
         break;
 
+      case token_type::kw_debugger:
       case token_type::kw_break:
       case token_type::kw_continue:
         this->lexer_.skip();

--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -1820,6 +1820,13 @@ TEST(test_parse, while_statement) {
   }
 }
 
+TEST(test_parse, debugger_statement) {
+  {
+    spy_visitor v = parse_and_visit_statement(u8"debugger;");
+    EXPECT_THAT(v.visits, IsEmpty());
+  }
+}
+
 TEST(test_parse, break_statement) {
   {
     spy_visitor v = parse_and_visit_statement(u8"break;");


### PR DESCRIPTION
Parsing a debugger statement follows the same behavior
as parsing statements like continue and break.

As far as I am concerned, the parser already knew that debugger
was a keyword and not an identifier.