### PR TITLE
Parse debugger statements

### DIFF
--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -158,6 +158,11 @@ class parser {
         this->consume_semicolon();
         break;
 
+      case token_type::kw_debugger:
+        this->lexer_.skip();
+        this->consume_semicolon();
+        break;
+
       case token_type::left_curly:
         v.visit_enter_block_scope();
         this->parse_and_visit_statement_block_no_scope(v);

--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -1833,5 +1833,19 @@ TEST(test_parse, continue_statement) {
     EXPECT_THAT(v.visits, IsEmpty());
   }
 }
+
+TEST(test_parse, debugger_statement) {
+  {
+    spy_visitor v;
+    padded_string code(u8"debugger; x;");
+    parser p(&code, &v);
+    p.parse_and_visit_statement(v);
+    p.parse_and_visit_statement(v);
+    EXPECT_THAT(v.errors, IsEmpty());
+    EXPECT_THAT(v.visits, ElementsAre("visit_variable_use"));
+    EXPECT_THAT(v.variable_uses,
+                ElementsAre(spy_visitor::visited_variable_use{u8"x"}));
+  }
+}
 }
 }


### PR DESCRIPTION
Parsing a `debugger` statement follows the same behavior as parsing a `break`/`continue` statement.

#6 As far as I am concerned, quick-lint-js already knew that `debugger` was a keyword and not an identifier.