### PR TITLE
Teaching quick-lint-js about number literals like 1_234_567

### DIFF
--- a/src/include/quick-lint-js/error.h
+++ b/src/include/quick-lint-js/error.h
@@ -58,6 +58,16 @@
       .error(u8"assignment to undeclared variable", assignment))               \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_underscores_not_allowed_at_end_of_numeric_literals,                \
+      { source_code_span where; },                                             \
+      .error(u8"underscores not allowed at end of numeric literals", where))   \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_only_one_underscore_is_allowed_as_numeric_separator,               \
+      { source_code_span where; },                                             \
+      .error(u8"only one underscore is allowed as numeric separator", where))  \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_big_int_literal_contains_decimal_point,                            \
       { source_code_span where; },                                             \
       .error(u8"BigInt literal contains decimal point", where))                \

--- a/src/include/quick-lint-js/error.h
+++ b/src/include/quick-lint-js/error.h
@@ -58,16 +58,6 @@
       .error(u8"assignment to undeclared variable", assignment))               \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_underscores_not_allowed_at_end_of_numeric_literals,                \
-      { source_code_span where; },                                             \
-      .error(u8"underscores not allowed at end of numeric literals", where))   \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
-      error_only_one_underscore_is_allowed_as_numeric_separator,               \
-      { source_code_span where; },                                             \
-      .error(u8"only one underscore is allowed as numeric separator", where))  \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
       error_big_int_literal_contains_decimal_point,                            \
       { source_code_span where; },                                             \
       .error(u8"BigInt literal contains decimal point", where))                \

--- a/src/include/quick-lint-js/lex.h
+++ b/src/include/quick-lint-js/lex.h
@@ -245,7 +245,7 @@ class lexer {
   void parse_binary_number();
   void parse_hexadecimal_number();
   void parse_number();
-  static const char8* parse_decimal_digits(const char8*) noexcept;
+  const char8* parse_decimal_digits_and_underscores(const char8*,const char8*) noexcept;
 
   void parse_identifier();
   static const char8* parse_identifier(const char8*);

--- a/src/include/quick-lint-js/lex.h
+++ b/src/include/quick-lint-js/lex.h
@@ -245,7 +245,7 @@ class lexer {
   void parse_binary_number();
   void parse_hexadecimal_number();
   void parse_number();
-  const char8* parse_decimal_digits_and_underscores(const char8* input,const char8* number_begin) noexcept;
+  const char8* parse_decimal_digits_and_underscores(const char8* input) noexcept;
 
   void parse_identifier();
   static const char8* parse_identifier(const char8*);

--- a/src/include/quick-lint-js/lex.h
+++ b/src/include/quick-lint-js/lex.h
@@ -245,7 +245,7 @@ class lexer {
   void parse_binary_number();
   void parse_hexadecimal_number();
   void parse_number();
-  const char8* parse_decimal_digits_and_underscores(const char8*,const char8*) noexcept;
+  const char8* parse_decimal_digits_and_underscores(const char8* input,const char8* number_begin) noexcept;
 
   void parse_identifier();
   static const char8* parse_identifier(const char8*);

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -663,11 +663,11 @@ void lexer::parse_number() {
     input = garbage_end;
   };
 
-  input = this->parse_decimal_digits_and_underscores(input, number_begin);
+  input = this->parse_decimal_digits_and_underscores(input);
   bool has_decimal_point = *input == '.';
   if (has_decimal_point) {
     input += 1;
-    input = this->parse_decimal_digits_and_underscores(input, number_begin);
+    input = this->parse_decimal_digits_and_underscores(input);
     has_decimal_point = true;
   }
   bool has_exponent = *input == 'e' || *input == 'E';
@@ -678,7 +678,7 @@ void lexer::parse_number() {
       input += 1;
     }
     if (this->is_digit(*input)) {
-      input = this->parse_decimal_digits_and_underscores(input, number_begin);
+      input = this->parse_decimal_digits_and_underscores(input);
     } else {
       input = e;
       consume_garbage();
@@ -709,8 +709,7 @@ void lexer::parse_number() {
   this->input_ = input;
 }
 
-const char8* lexer::parse_decimal_digits_and_underscores(const char8* input, 
-    const char8* number_begin) noexcept {
+const char8* lexer::parse_decimal_digits_and_underscores(const char8* input) noexcept {
   bool has_trailing_underscore = false;
   while (is_digit(*input)) {
     has_trailing_underscore = false;

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -720,16 +720,12 @@ const char8* lexer::parse_decimal_digits_and_underscores(const char8* input,
       input += 1;
       if (*input == '_') {
         has_trailing_underscore = false;
-        this->error_reporter_->report(
-            error_only_one_underscore_is_allowed_as_numeric_separator{
-            source_code_span(number_begin, input)});
+        // TODO error_reporter: SyntaxError: Only one underscore is allowed in numeric separator
       }
     }
   }
   if (has_trailing_underscore == true) {
-    this->error_reporter_->report(
-        error_underscores_not_allowed_at_end_of_numeric_literals{
-        source_code_span(number_begin, input)});
+    // TODO error_reporter: SyntaxError: Numeric separators are not allowed at the end of numeric literals
   }
   return input;
 }

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -97,14 +97,19 @@ TEST(test_lex, lex_numbers) {
   check_single_token(u8"1e-3", token_type::number);
   check_single_token(u8"1e+3", token_type::number);
   check_single_token(u8"1E+3", token_type::number);
+  check_single_token(u8"1E1_3_2", token_type::number);
 
   check_single_token(u8"0n", token_type::number);
   check_single_token(u8"123456789n", token_type::number);
+
+  check_single_token(u8"123_123_123", token_type::number);
+  check_single_token(u8"123.123_123", token_type::number);
 
   check_tokens(u8"123. 456", {token_type::number, token_type::number});
 
   check_tokens(u8"1.2.3", {token_type::number, token_type::number});
   check_tokens(u8".2.3", {token_type::number, token_type::number});
+
 }
 
 TEST(test_lex, lex_binary_numbers) {


### PR DESCRIPTION
I left TODO comments for once the error reporting is changed, but the logic for __ and trailing _ is throwing an error is done(I think?).

I called parse underscore in parse decimal to handle numbers like 1.234_567 this also solves 3e1_2 because exponents section calls parse decimal which if it has underscore in the number calls parse underscore.

Update:  for the trailing underscore I added a boolean value.