### PR TITLE
 Report error when `throw` statement is incomplete or has newline.

### DIFF
--- a/src/include/quick-lint-js/error.h
+++ b/src/include/quick-lint-js/error.h
@@ -72,6 +72,14 @@
       .error(u8"BigInt literal has a leading 0 digit", where))                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_expected_expression_before_newline, { source_code_span where; },   \
+      .error(u8"expected expression before newline", where))                   \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_expected_expression_before_semicolon, { source_code_span where; }, \
+      .error(u8"expected expression before semicolon", where))                 \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_invalid_binding_in_let_statement, { source_code_span where; },     \
       .error(u8"invalid binding in let statement", where))                     \
                                                                                \

--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -122,10 +122,27 @@ class parser {
         break;
 
       case token_type::kw_return:
+        this->lexer_.skip();
+        if (this->peek().type == token_type::semicolon) {
+          this->lexer_.skip();
+          break;
+        }
+        this->parse_and_visit_expression(v);
+        this->consume_semicolon();
+        break;
+
       case token_type::kw_throw:
         this->lexer_.skip();
         if (this->peek().type == token_type::semicolon) {
-          // TODO(strager): Require expression for throw statements.
+          this->error_reporter_->report(
+              error_expected_expression_before_semicolon{this->peek().span()});
+          this->lexer_.skip();
+          break;
+        }
+        if (this->peek().has_leading_newline) {
+          this->lexer_.insert_semicolon();
+          this->error_reporter_->report(
+              error_expected_expression_before_newline{this->peek().span()});
           this->lexer_.skip();
           break;
         }

--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -448,6 +448,26 @@ TEST(test_parse, throw_statement) {
     EXPECT_THAT(v.variable_uses,
                 ElementsAre(spy_visitor::visited_variable_use{u8"Error"}));
   }
+
+  {
+    spy_visitor v;
+    padded_string code(u8"throw;");
+    parser p(&code, &v);
+    p.parse_and_visit_statement(v);
+    EXPECT_THAT(v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(error_expected_expression_before_semicolon, where,
+            offsets_matcher(&code, 5, 6))));
+  }
+
+  {
+    spy_visitor v;
+    padded_string code(u8"throw\nnew Error();");
+    parser p(&code, &v);
+    p.parse_and_visit_statement(v);
+    EXPECT_THAT(v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(error_expected_expression_before_newline, where,
+            offsets_matcher(&code, 5, 5))));
+  }
 }
 
 TEST(test_parse, parse_math_expression) {


### PR DESCRIPTION
 `expected expression` is reported when `throw` is followed by
 semicolon.
 `unexpected newline` is reported when `throw` is followed by a newline.