### PR TITLE
Add errors for consecutive underscores

### DIFF
--- a/src/include/quick-lint-js/error.h
+++ b/src/include/quick-lint-js/error.h
@@ -72,11 +72,6 @@
       .error(u8"BigInt literal has a leading 0 digit", where))                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
-      error_number_literal_contains_consecutive_underscores,                   \
-      { source_code_span where; },                                             \
-      .error(u8"Number literal contains consecutive underscores", where))      \
-                                                                               \
-  QLJS_ERROR_TYPE(                                                             \
       error_invalid_binding_in_let_statement, { source_code_span where; },     \
       .error(u8"invalid binding in let statement", where))                     \
                                                                                \
@@ -101,6 +96,11 @@
   QLJS_ERROR_TYPE(                                                             \
       error_missing_semicolon_after_expression, { source_code_span where; },   \
       .error(u8"missing semicolon after expression", where))                   \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
+      error_number_literal_contains_consecutive_underscores,                   \
+      { source_code_span underscores; },                                       \
+      .error(u8"number literal contains consecutive underscores", underscores))\
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
       error_redeclaration_of_global_variable, { identifier redeclaration; },   \

--- a/src/include/quick-lint-js/error.h
+++ b/src/include/quick-lint-js/error.h
@@ -72,6 +72,11 @@
       .error(u8"BigInt literal has a leading 0 digit", where))                 \
                                                                                \
   QLJS_ERROR_TYPE(                                                             \
+      error_number_literal_contains_consecutive_underscores,                   \
+      { source_code_span where; },                                             \
+      .error(u8"Number literal contains consecutive underscores", where))      \
+                                                                               \
+  QLJS_ERROR_TYPE(                                                             \
       error_invalid_binding_in_let_statement, { source_code_span where; },     \
       .error(u8"invalid binding in let statement", where))                     \
                                                                                \

--- a/src/include/quick-lint-js/lex.h
+++ b/src/include/quick-lint-js/lex.h
@@ -246,7 +246,7 @@ class lexer {
   void parse_hexadecimal_number();
   const char8* check_garbage_in_number_literal(const char8* input);
   void parse_number();
-  static const char8* parse_decimal_digits_and_underscores(
+  const char8* parse_decimal_digits_and_underscores(
       const char8* input) noexcept;
 
   void parse_identifier();

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -708,6 +708,20 @@ void lexer::parse_number() {
           source_code_span(number_begin, input)});
     }
   }
+  if (*input == '_') {
+    const char8* garbage_end = input + 1;
+
+    while (*input == '_') {
+      input -= 1;
+    }
+
+    const char8* garbage_begin = input + 1;
+
+    this->error_reporter_->report(error_number_literal_contains_consecutive_underscores{
+        source_code_span(garbage_begin, garbage_end)});
+
+    input = garbage_end;
+  }
 
   switch (*input) {
   QLJS_CASE_IDENTIFIER_START:
@@ -727,9 +741,14 @@ const char8* lexer::parse_decimal_digits_and_underscores(
       has_trailing_underscore = true;
       input += 1;
       if (*input == '_') {
+        const char8* garbage_begin = input - 1;
         has_trailing_underscore = false;
-        // TODO error_reporter: SyntaxError: Only one underscore is allowed
-        // innumeric separator
+
+        while (*input == '_') {
+          input += 1;
+        }
+
+        input -= 1;
       }
     }
   }

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -734,10 +734,8 @@ const char8* lexer::parse_decimal_digits_and_underscores(
           input += 1;
         }
 
-        const char8* garbage_end = input;
-
         this->error_reporter_->report(error_number_literal_contains_consecutive_underscores{
-            source_code_span(garbage_begin, garbage_end)});
+            source_code_span(garbage_begin, input)});
       }
     }
   }

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -724,10 +724,10 @@ const char8* lexer::parse_decimal_digits_and_underscores(
     has_trailing_underscore = false;
     input += 1;
     if (*input == '_') {
+      const char8* garbage_begin = input;
       has_trailing_underscore = true;
       input += 1;
       if (*input == '_') {
-        const char8* garbage_begin = input - 1;
         has_trailing_underscore = false;
 
         while (*input == '_') {

--- a/src/lex.cpp
+++ b/src/lex.cpp
@@ -708,20 +708,6 @@ void lexer::parse_number() {
           source_code_span(number_begin, input)});
     }
   }
-  if (*input == '_') {
-    const char8* garbage_end = input + 1;
-
-    while (*input == '_') {
-      input -= 1;
-    }
-
-    const char8* garbage_begin = input + 1;
-
-    this->error_reporter_->report(error_number_literal_contains_consecutive_underscores{
-        source_code_span(garbage_begin, garbage_end)});
-
-    input = garbage_end;
-  }
 
   switch (*input) {
   QLJS_CASE_IDENTIFIER_START:
@@ -748,7 +734,10 @@ const char8* lexer::parse_decimal_digits_and_underscores(
           input += 1;
         }
 
-        input -= 1;
+        const char8* garbage_end = input;
+
+        this->error_reporter_->report(error_number_literal_contains_consecutive_underscores{
+            source_code_span(garbage_begin, garbage_end)});
       }
     }
   }

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -309,7 +309,7 @@ TEST(test_lex, lex_number_with_double_underscore) {
     EXPECT_EQ(l.peek().type, token_type::end_of_file);
 
     EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
-                              error_number_literal_contains_consecutive_underscores, where,
+                              error_number_literal_contains_consecutive_underscores, underscores,
                               offsets_matcher(&input, 3, 5))));
   }
 }
@@ -324,7 +324,7 @@ TEST(test_lex, lex_number_with_many_underscores) {
     EXPECT_EQ(l.peek().type, token_type::end_of_file);
 
     EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
-                              error_number_literal_contains_consecutive_underscores, where,
+                              error_number_literal_contains_consecutive_underscores, underscores,
                               offsets_matcher(&input, 3, 8))));
   }
 }
@@ -341,10 +341,10 @@ TEST(test_lex, lex_number_with_multiple_groups_of_consecutive_underscores) {
 
     EXPECT_THAT(v.errors, ElementsAre(
           ERROR_TYPE_FIELD(
-            error_number_literal_contains_consecutive_underscores, where,
+            error_number_literal_contains_consecutive_underscores, underscores,
             offsets_matcher(&input, 3, 5)),
           ERROR_TYPE_FIELD(
-            error_number_literal_contains_consecutive_underscores, where,
+            error_number_literal_contains_consecutive_underscores, underscores,
             offsets_matcher(&input, 7, 10))));
   }
 }

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -306,9 +306,6 @@ TEST(test_lex, lex_number_with_double_underscore) {
     lexer l(&input, &v);
     EXPECT_EQ(l.peek().type, token_type::number);
     l.skip();
-    EXPECT_EQ(l.peek().type, token_type::number);
-    EXPECT_EQ(*l.peek().begin, '0');
-    l.skip();
     EXPECT_EQ(l.peek().type, token_type::end_of_file);
 
     EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
@@ -323,9 +320,6 @@ TEST(test_lex, lex_number_with_many_underscores) {
     padded_string input(u8"123_____000");
     lexer l(&input, &v);
     EXPECT_EQ(l.peek().type, token_type::number);
-    l.skip();
-    EXPECT_EQ(l.peek().type, token_type::number);
-    EXPECT_EQ(*l.peek().begin, '0');
     l.skip();
     EXPECT_EQ(l.peek().type, token_type::end_of_file);
 
@@ -342,12 +336,6 @@ TEST(test_lex, lex_number_with_multiple_groups_of_consecutive_underscores) {
     lexer l(&input, &v);
     EXPECT_EQ(l.peek().type, token_type::number);
     EXPECT_EQ(*l.peek().begin, '1');
-    l.skip();
-    EXPECT_EQ(l.peek().type, token_type::number);
-    EXPECT_EQ(*l.peek().begin, '4');
-    l.skip();
-    EXPECT_EQ(l.peek().type, token_type::number);
-    EXPECT_EQ(*l.peek().begin, '6');
     l.skip();
     EXPECT_EQ(l.peek().type, token_type::end_of_file);
 

--- a/test/test-lex.cpp
+++ b/test/test-lex.cpp
@@ -299,6 +299,68 @@ TEST(test_lex, lex_invalid_big_int_number) {
   }
 }
 
+TEST(test_lex, lex_number_with_double_underscore) {
+  {
+    error_collector v;
+    padded_string input(u8"123__000");
+    lexer l(&input, &v);
+    EXPECT_EQ(l.peek().type, token_type::number);
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::number);
+    EXPECT_EQ(*l.peek().begin, '0');
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::end_of_file);
+
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_number_literal_contains_consecutive_underscores, where,
+                              offsets_matcher(&input, 3, 5))));
+  }
+}
+
+TEST(test_lex, lex_number_with_many_underscores) {
+  {
+    error_collector v;
+    padded_string input(u8"123_____000");
+    lexer l(&input, &v);
+    EXPECT_EQ(l.peek().type, token_type::number);
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::number);
+    EXPECT_EQ(*l.peek().begin, '0');
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::end_of_file);
+
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_number_literal_contains_consecutive_underscores, where,
+                              offsets_matcher(&input, 3, 8))));
+  }
+}
+
+TEST(test_lex, lex_number_with_multiple_groups_of_consecutive_underscores) {
+  {
+    error_collector v;
+    padded_string input(u8"123__45___6");
+    lexer l(&input, &v);
+    EXPECT_EQ(l.peek().type, token_type::number);
+    EXPECT_EQ(*l.peek().begin, '1');
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::number);
+    EXPECT_EQ(*l.peek().begin, '4');
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::number);
+    EXPECT_EQ(*l.peek().begin, '6');
+    l.skip();
+    EXPECT_EQ(l.peek().type, token_type::end_of_file);
+
+    EXPECT_THAT(v.errors, ElementsAre(
+          ERROR_TYPE_FIELD(
+            error_number_literal_contains_consecutive_underscores, where,
+            offsets_matcher(&input, 3, 5)),
+          ERROR_TYPE_FIELD(
+            error_number_literal_contains_consecutive_underscores, where,
+            offsets_matcher(&input, 7, 10))));
+  }
+}
+
 TEST(test_lex, lex_strings) {
   check_single_token(u8R"('hello')", token_type::string);
   check_single_token(u8R"("hello")", token_type::string);


### PR DESCRIPTION
Here is my attempt at #32.

I have one question (at least). When I use `u8"123___45___67"` as input, `"123___"`, `"45___"`, and `"67"` are all considered different tokens. I found this out when I was getting a test failure that I was not at `token_type::end_of_file`. Is this intentional, or do you want me to include an update to make it consider the whole thing one token?

On one hand, it seems like it should be one token. On the other hand, each group of consecutive underscores is currently reported as a separate linting error, with no special walking to make it happen.

I look forward to your feedback. I haven't written C++ since high school 20 years ago, so I appreciate you letting us contribute!