### PR TITLE
Report missing semicolon for variable declarations and report debugger as invalid binding in let statement

### DIFF
--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -908,6 +908,7 @@ class parser {
         case token_type::number:
           this->error_reporter_->report(
               error_invalid_binding_in_let_statement{this->peek().span()});
+          this->lexer_.skip();
           break;
         default:
           if (first_binding) {

--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -372,9 +372,7 @@ class parser {
       case token_type::kw_let:
       case token_type::kw_var:
         this->parse_and_visit_let_bindings(v, this->peek().type);
-        if (this->peek().type == token_type::semicolon) {
-          this->lexer_.skip();
-        }
+        this->consume_semicolon();
         break;
 
       case token_type::kw_function:

--- a/src/include/quick-lint-js/parse.h
+++ b/src/include/quick-lint-js/parse.h
@@ -905,6 +905,13 @@ class parser {
           this->parse_and_visit_binding_element(v, declaration_kind);
           break;
         case token_type::kw_if:
+        case token_type::kw_break:
+        case token_type::kw_continue:
+        case token_type::kw_debugger:
+        case token_type::kw_false:
+        case token_type::kw_null:
+        case token_type::kw_true:
+        case token_type::kw_void:
         case token_type::number:
           this->error_reporter_->report(
               error_invalid_binding_in_let_statement{this->peek().span()});

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -528,11 +528,16 @@ next:
     case token_type::end_of_file:
     case token_type::identifier:
     case token_type::kw_const:
+    case token_type::kw_debugger:
+    case token_type::kw_do:
+    case token_type::kw_for:
     case token_type::kw_from:
     case token_type::kw_let:
     case token_type::kw_of:
     case token_type::kw_return:
+    case token_type::kw_switch:
     case token_type::kw_var:
+    case token_type::kw_while:
     case token_type::left_curly:
     case token_type::right_curly:
     case token_type::right_paren:

--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -350,6 +350,17 @@ TEST(test_parse, parse_invalid_let) {
                               error_invalid_binding_in_let_statement, where,
                               offsets_matcher(&code, 4, 6))));
   }
+
+  {
+    spy_visitor v;
+    padded_string code(u8"let debugger");
+    parser p(&code, &v);
+    p.parse_and_visit_statement(v);
+    EXPECT_EQ(v.variable_declarations.size(), 0);
+    EXPECT_THAT(v.errors, ElementsAre(ERROR_TYPE_FIELD(
+                              error_invalid_binding_in_let_statement, where,
+                              offsets_matcher(&code, 4, 12))));
+  }
 }
 
 TEST(test_parse, parse_and_visit_import) {


### PR DESCRIPTION
For report missing semicolon for variable declarations, I left out the `if`, `try`, `with`, `class`, and `function` cases. I wasn't too sure if they should all be included. On second thought they probably should be included.

I was going to add more cases, for report invalid binding in let statement, but things are already getting messy. I'm not sure if you should be able to recover from the `if` case (just telling the lexer to skip). For the number and `debugger` case, I believe you should be able to just skip over and continue because it is one token.

I wasn't sure how to title the commit. I wanted to have two separate commits, "Report missing semicolon for variable declarations" and "Report debugger as invalid binding in let statement", but I couldn't figure out how to split the commit into two.

Also not sure about the test cases, they might be redundant?