### PR TITLE
Add nix build expressions and instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/result

--- a/dist/default.nix
+++ b/dist/default.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+{
+  quick-lint-js = pkgs.callPackage ./quick-lint-js.nix { };
+
+  # TODO: add expression for vim plugin
+}

--- a/dist/quick-lint-js.nix
+++ b/dist/quick-lint-js.nix
@@ -1,0 +1,33 @@
+{ pkgs
+, stdenv ? pkgs.stdenv
+, lib ? stdenv.lib
+, mkDerivation ? stdenv.mkDerivation
+
+, buildType ? "Release"
+, doCheck ? true
+, dontFixCmake ? false
+}:
+
+mkDerivation {
+  pname = "quick-lint-js";
+  # nix conventions tell us to use a version string starting with
+  # a number or the "current" date. Since this is a rolling derivation
+  # we can't give a date, and we currently have no version numbers.
+  # FIXME as soon as we introduce version numbers.
+  version = "0";
+
+  src = ../.;
+  unpackPhase = null;
+
+  nativeBuildInputs = with pkgs; [ cmake ninja ];
+  cmakeBuildType = buildType;
+  doCheck = doCheck;
+  dontFixCmake = dontFixCmake;
+
+  meta = with lib; {
+    description = "quick-lint-js finds bugs in JavaScript programs";
+    homepage = "https://github.com/strager/quick-lint-js";
+    license = licenses.gpl3Plus;
+    platforms = platforms.all;
+  };
+}

--- a/dist/shell.nix
+++ b/dist/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> { }
+, buildType ? "Debug"
+# Without disabling fixing, code in vendor/ will be modified when building
+# interactively.
+, dontFixCmake ? true
+, ...
+}:
+
+{
+  quick-lint-js = pkgs.callPackage ./quick-lint-js.nix {
+    inherit pkgs buildType dontFixCmake;
+  };
+}

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -16,6 +16,7 @@ development environment and build tool:
 * [macOS and Linux: Ninja](#macos-and-linux-ninja)
 * [macOS and Linux: make](#macos-and-linux-make)
 * [Windows: Visual Studio](#windows-visual-studio)
+* [macOS and Linux: nix](#macos-and-linux-nix)
 
 ---
 
@@ -122,6 +123,61 @@ If you want to run the quick-lint-js program, you can find it in
 `build\Debug\quick-lint-js.exe`. Run it from a command prompt or PowerShell
 window.
 
+---
+
+### macOS and Linux: nix
+
+This is for advanced users only. You need to
+[install the Nix package manager](https://nixos.org/download.html) if you have
+not already done so.
+
+[Nix][] uses derivation files that contain instructions for automation on how
+to build and package software. The `dist/` folder contains such derivations for
+quick-lint-js and can be used to download dependencies and build it.
+
+#### 0. Prepare environment
+
+The derivations in `dist/` contain the necessary dependencies to build
+quick-lint-js using cmake and ninja. We can use `nix-shell` to download those
+dependencies and make them available for development.
+
+    $ nix-shell dist/shell.nix
+
+While it seems this does not do anything, you will be dropped in a shell that
+has the build tools available necessary to build quick-lint-js. Once you exit
+this shell, the downloaded dependencies will not be available anymore. You
+can use the above command again to re-create a shell with the build tools
+available at any time.
+
+#### 1. Configure
+
+After running above command, we configure the build environment:
+
+    $ cmakeConfigurePhase
+
+This will create a `build/` folder in the project folder and changes the
+current directory to it.
+
+#### 2. Build
+
+To build quick-lint-js, make sure you are in the `build/` folder; the
+previous command should have already put you there. To start the build
+using ninja, you use:
+
+    $ ninjaBuildPhase
+
+#### 3. Run
+
+After building, the binary is available as `quick-lint-js` in the build
+folder:
+
+    $ ./quick-lint-js
+
+To run the tests, execute the test binary in the build directory:
+
+    $ ./test/quick-lint-js-test
+
 [CMake]: https://cmake.org/
 [Ninja]: https://ninja-build.org/
 [Visual Studio]: https://visualstudio.microsoft.com/vs/
+[Nix]: https://nixos.org/manual/nix/stable/

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -1,0 +1,44 @@
+# Installing quick-lint-js
+
+## Installing from source
+
+Even though quick-lint-js is still in early development, you might want to
+experiment with installing the binary in your environment. Currently we do not
+offer pre-built binaries so quick-lint-js needs to be installed from source.
+
+Depending on how you want to build quick-lint-js, the installation instructions
+might differ.
+
+* [macOS and Linux: nix](#macos-and-linux-nix)
+
+---
+
+### macOS and Linux: nix
+
+This is for advanced users only. You need to
+[install the Nix package manager](https://nixos.org/download.html) if you have
+not already done so.
+
+#### Build and Install
+
+[Nix][] uses derivation files that contain instructions for automation on how
+to build and package software. The `dist/` folder contains such derivations and
+can be used to build and install quick-lint-js from source. Nix will automatically
+download all dependencies, so installing dependencies other than nix yourself is
+not necessary.
+
+Use `nix-env -i` to build and install the binary all in one go:
+
+    $ nix-env -f dist -i
+
+Now the binary is available in your user path:
+
+    $ quick-lint-js --help
+
+#### Uninstall
+
+Use `nix-env -e` to uninstall a previously installed binary from your user env:
+
+    $ nix-env -e quick-lint-js
+
+[Nix]: https://nixos.org/features.html


### PR DESCRIPTION
This adds a new directory containing packaging tools `dist/`. For now,
this only includes nix derivations which allow building and packaging
through the nix package manager[1].

Most of the work for the nix derivation is done by the build hook for
cmake[2]. There is some funkyness going on during the install phase
so we overwrite it with our custom installPhase that only installs
the binary file. This can be extended in the future to also include
library files and manpages (if applicable).

The build results are:
```
$ tree result
result
└── bin
    └── quick-lint-js

1 directory, 1 file
```

## Testing
```
$ ./result/bin/quick-lint-js --help
Usage: quick-lint-js [OPTIONS]... [FILE]...

OPTIONS
--output-format=[FORMAT]            Format to print feedback where FORMAT is one of:
                                    gnu-like (default if omitted), vim-qflist-json
--vim-file-bufnr=[NUMBER]           Select a vim buffer for outputting feedback
--h, --help                         Print help message
```

Using `nix-env -i`:
```
$ nix-env -f dist -i
[...]
cmake: enabled parallel building
building
build flags: -j2 -l2
[94/94] Linking CXX executable test/quick-lint-js-test-test.dir/test-vim-qflist-json-error-reporter.cpp.o[Ksource.cpp.o
running tests
check flags: -j2 -l2 test
[0/1] Running tests...
Test project /build/quick-lint-js/build
    Start 1: quick-lint-js-test
1/1 Test #1: quick-lint-js-test ...............   Passed    0.51 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.51 sec
installing
[...]
```


```
$ cat > test.js
function test() { return "Hello"; }
let test = 123;
var test = "Hi";
$ quick-lint-js test.js 
test.js:2:5: error: redeclaration of variable: test
test.js:1:10: note: variable already declared here
```



[1] https://nixos.org/manual/nixpkgs/stable/
[2] https://nixos.wiki/wiki/C#cmake