### PR TITLE
Test continue parsing after invalid let binding

### DIFF
--- a/test/test-parse.cpp
+++ b/test/test-parse.cpp
@@ -361,6 +361,21 @@ TEST(test_parse, parse_invalid_let) {
                               error_invalid_binding_in_let_statement, where,
                               offsets_matcher(&code, 4, 12))));
   }
+
+  {
+    spy_visitor v;
+    padded_string code(u8"let true, true, y\nlet x;");
+    parser p(&code, &v);
+    p.parse_and_visit_statement(v);
+    p.parse_and_visit_statement(v);
+    EXPECT_EQ(v.variable_declarations.size(), 2);
+    EXPECT_THAT(
+        v.errors,
+        ElementsAre(ERROR_TYPE_FIELD(error_invalid_binding_in_let_statement,
+                                     where, offsets_matcher(&code, 4, 8)),
+                    ERROR_TYPE_FIELD(error_invalid_binding_in_let_statement,
+                                     where, offsets_matcher(&code, 10, 14))));
+  }
 }
 
 TEST(test_parse, parse_and_visit_import) {


### PR DESCRIPTION
In pull request #39 I forgot to write a test for the commit "Continue parsing after invalid let binding".